### PR TITLE
Add support for sending mParticle events when an experiment is viewed

### DIFF
--- a/src/main/java/com/mparticle/kits/ApptimizeKit.java
+++ b/src/main/java/com/mparticle/kits/ApptimizeKit.java
@@ -60,6 +60,7 @@ public class ApptimizeKit
     private ApptimizeOptions buildApptimizeOptions(final Map<String, String> settings) {
         ApptimizeOptions o = new ApptimizeOptions();
         o.setThirdPartyEventImportingEnabled(false);
+        o.setThirdPartyEventExportingEnabled(false);
         configureApptimizeUpdateMetaDataTimeout(o, settings);
         configureApptimizeDeviceName(o, settings);
         configureApptimizeDeveloperModeDisabled(o, settings);


### PR DESCRIPTION
(Exactly the same as for https://github.com/mparticle-integrations/mparticle-apple-integration-apptimize/pull/2, just this is for Android).

This adds support for sending mParticle events via the logEvent method whenever an experiment participation has occurred. I have verified this works and sends the expected data from our end, but I am unable to test to see whether the data is correct upon reception. I assume it is.

The only other thing I haven't tested is the flag to enable/disable these events. I have called it "trackExperiments" for now; if you want a different name please let me know.