### PR TITLE
Update Apptimize SDK to 2.13.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,5 +15,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.apptimize:apptimize-android:2.13.0'
+    compile 'com.apptimize:apptimize-android:2.13.5'
 }


### PR DESCRIPTION
```
Hi Vijay,

We recently identified and fixed a rare deadlock/ANR issue in our Android SDK. This may or may not apply to your app but we recommend updating to Android SDK 2.13.5 at your earliest convenience. Please contact support if you have any questions. 

Thank you!

Apptimize Team 
```