### PR TITLE
fix: bugfix http url

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the [Apptimize](https://www.apptimize.com/) integration
     ```groovy
     repositories {
         maven {
-            url 'http://maven.apptimize.com/artifactory/repo'
+            url 'https://maven.apptimize.com/artifactory/repo'
         }
     }
     ```
@@ -25,8 +25,8 @@ This repository contains the [Apptimize](https://www.apptimize.com/) integration
 
 ### Documentation
 
-[Apptimize integration](http://docs.mparticle.com/?java#apptimize)
+[Apptimize integration](https://docs.mparticle.com/?java#apptimize)
 
 ### License
 
-[Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 apply plugin: 'com.mparticle.kit'
 
 repositories {
-    maven { url 'http://maven.apptimize.com/artifactory/repo' }
+    maven { url 'https://maven.apptimize.com/artifactory/repo' }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
Updated `http://` urls to `https://` blocking lint in AGP 7.X upgrade

## Testing Plan
Check if any other `http://` references exist to upgrade