### PR TITLE
Fix link to Apptimize integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository contains the [Apptimize](https://www.apptimize.com/) integration
 
 ### Documentation
 
-[Apptimize integration](https://docs.mparticle.com/?java#apptimize)
+[Apptimize integration](https://docs.mparticle.com/integrations/apptimize)
 
 ### License
 


### PR DESCRIPTION
# Summary

The link to the mParticle Apptimize integration guide was broken - this PR adds the correct URL.
